### PR TITLE
Error handling

### DIFF
--- a/js/src/test/kotlin/exceptions.kt
+++ b/js/src/test/kotlin/exceptions.kt
@@ -1,0 +1,38 @@
+import kotlinx.html.consumers.catch
+import kotlinx.html.dom.append
+import kotlinx.html.h1
+import kotlinx.html.h2
+import kotlinx.html.js.div
+import org.junit.Test
+import kotlin.browser.document
+import kotlin.test.assertEquals
+
+class TestExceptions {
+
+    @Test fun `exception_handler_should_add_output`() {
+
+        val container = document.body!!.append.catch { err ->
+
+            div {
+                +"ERROR: "
+                +err.message!!
+            }
+
+        }.div {
+            h1 {
+                +" text "
+                throw IllegalStateException("testing errors")
+            }
+            h2 {
+                +" should be present "
+            }
+        }
+
+        assertEquals(
+                """<h1> text <div>ERROR: testing errors</div></h1><h2> should be present </h2>""",
+                container.innerHTML.trimTagSpace())
+    }
+
+    fun String.trimTagSpace() = replace(">\\s+<".toRegex(), "><")
+}
+

--- a/jvm/src/test/kotlin/exceptions.kt
+++ b/jvm/src/test/kotlin/exceptions.kt
@@ -1,5 +1,5 @@
 import kotlinx.html.*
-import kotlinx.html.consumers.delayed
+import kotlinx.html.consumers.catch
 import kotlinx.html.stream.appendHTML
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -39,11 +39,13 @@ class TestExceptions {
     @Test fun `exception handler should add output`() {
 
         val sb = StringBuilder()
-        sb.appendHTML(prettyPrint = false).catch {
+        sb.appendHTML(prettyPrint = false).catch { err ->
+
             div {
                 +"ERROR: "
-                +it.message!!
+                +err.message!!
             }
+
         }.html {
             body {
                 h1 {

--- a/jvm/src/test/kotlin/exceptions.kt
+++ b/jvm/src/test/kotlin/exceptions.kt
@@ -1,4 +1,5 @@
 import kotlinx.html.*
+import kotlinx.html.consumers.delayed
 import kotlinx.html.stream.appendHTML
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -15,11 +16,11 @@ class TestExceptions {
             sb.appendHTML(prettyPrint = false).html {
                 body {
                     h1 {
-                        +"empty"
+                        +" empty "
                         throw IllegalStateException("testing errors")
                     }
                     h2 {
-                        +"should NOT be written"
+                        +" should NOT be written "
                     }
                 }
             }
@@ -31,34 +32,33 @@ class TestExceptions {
         assertTrue(errorCaught, "Exception should be not re-thrown")
 
         assertEquals(
-                "<html><body><h1>empty</h1></body></html>",
+                """<html><body><h1> empty </h1></body></html>""",
                 sb.toString())
     }
 
     @Test fun `exception handler should add output`() {
 
         val sb = StringBuilder()
-        TestExceptionConsumer(sb.appendHTML(prettyPrint = false)).html {
+        sb.appendHTML(prettyPrint = false).catch {
+            div {
+                +"ERROR: "
+                +it.message!!
+            }
+        }.html {
             body {
                 h1 {
+                    +" text "
                     throw IllegalStateException("testing errors")
                 }
                 h2 {
-                    +"should be present"
+                    +" should be present "
                 }
             }
         }
 
         assertEquals(
-                "<html><body><h1><div>error was handled</div></h1><h2>should be present</h2></body></html>",
+                """<html><body><h1> text <div>ERROR: testing errors</div></h1><h2> should be present </h2></body></html>""",
                 sb.toString())
     }
 }
 
-private class TestExceptionConsumer<R>(val underlying: TagConsumer<R>) : TagConsumer<R> by underlying {
-    override fun onError(tag: Tag, exception: Exception) {
-
-        div { +"error was handled" }
-
-    }
-}

--- a/jvm/src/test/kotlin/exceptions.kt
+++ b/jvm/src/test/kotlin/exceptions.kt
@@ -1,0 +1,64 @@
+import kotlinx.html.*
+import kotlinx.html.stream.appendHTML
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TestExceptions {
+    @Test fun `default exception must result in empty tag`() {
+
+        val sb = StringBuilder()
+
+        var errorCaught = false
+
+        try {
+            sb.appendHTML(prettyPrint = false).html {
+                body {
+                    h1 {
+                        +"empty"
+                        throw IllegalStateException("testing errors")
+                    }
+                    h2 {
+                        +"should NOT be written"
+                    }
+                }
+            }
+        } catch (err: IllegalStateException) {
+            errorCaught = true
+            assertEquals(err.message, "testing errors")
+        }
+
+        assertTrue(errorCaught, "Exception should be not re-thrown")
+
+        assertEquals(
+                "<html><body><h1>empty</h1></body></html>",
+                sb.toString())
+    }
+
+    @Test fun `exception handler should add output`() {
+
+        val sb = StringBuilder()
+        TestExceptionConsumer(sb.appendHTML(prettyPrint = false)).html {
+            body {
+                h1 {
+                    throw IllegalStateException("testing errors")
+                }
+                h2 {
+                    +"should be present"
+                }
+            }
+        }
+
+        assertEquals(
+                "<html><body><h1><div>error was handled</div></h1><h2>should be present</h2></body></html>",
+                sb.toString())
+    }
+}
+
+private class TestExceptionConsumer<R>(val underlying: TagConsumer<R>) : TagConsumer<R> by underlying {
+    override fun onError(tag: Tag, exception: Exception) {
+
+        div { +"error was handled" }
+
+    }
+}

--- a/jvm/src/test/kotlin/exceptions.kt
+++ b/jvm/src/test/kotlin/exceptions.kt
@@ -29,7 +29,7 @@ class TestExceptions {
             assertEquals(err.message, "testing errors")
         }
 
-        assertTrue(errorCaught, "Exception should be not re-thrown")
+        assertTrue(errorCaught, "Exception should be thrown")
 
         assertEquals(
                 """<html><body><h1> empty </h1></body></html>""",

--- a/shared/src/main/kotlin/api.kt
+++ b/shared/src/main/kotlin/api.kt
@@ -11,7 +11,7 @@ interface TagConsumer<out R> {
     fun onTagContent(content: CharSequence)
     fun onTagContentEntity(entity: Entities)
     fun onTagContentUnsafe(block: Unsafe.() -> Unit)
-    fun onError(tag: Tag, exception: Exception): Unit = throw exception
+    fun onTagError(tag: Tag, exception: Throwable): Unit = throw exception
     fun finalize(): R
 }
 
@@ -48,7 +48,7 @@ fun <T : Tag> T.visit(block: T.() -> Unit) {
     try {
         this.block()
     } catch (err: Exception) {
-        consumer.onError(this, err)
+        consumer.onTagError(this, err)
     } finally {
         consumer.onTagEnd(this)
     }

--- a/shared/src/main/kotlin/delayed-consumer.kt
+++ b/shared/src/main/kotlin/delayed-consumer.kt
@@ -41,6 +41,11 @@ class DelayedConsumer<T>(val downstream : TagConsumer<T>) : TagConsumer<T> {
         downstream.onTagContentEntity(entity)
     }
 
+    override fun onError(tag: Tag, exception: Exception) {
+        processDelayedTag()
+        downstream.onError(tag, exception)
+    }
+
     override fun finalize(): T {
         processDelayedTag()
         return downstream.finalize()

--- a/shared/src/main/kotlin/delayed-consumer.kt
+++ b/shared/src/main/kotlin/delayed-consumer.kt
@@ -41,9 +41,9 @@ class DelayedConsumer<T>(val downstream : TagConsumer<T>) : TagConsumer<T> {
         downstream.onTagContentEntity(entity)
     }
 
-    override fun onError(tag: Tag, exception: Exception) {
+    override fun onTagError(tag: Tag, exception: Throwable) {
         processDelayedTag()
-        downstream.onError(tag, exception)
+        downstream.onTagError(tag, exception)
     }
 
     override fun finalize(): T {

--- a/shared/src/main/kotlin/exception-consumer.kt
+++ b/shared/src/main/kotlin/exception-consumer.kt
@@ -1,0 +1,17 @@
+import kotlinx.html.Tag
+import kotlinx.html.TagConsumer
+import kotlinx.html.div
+
+private class DelegatingExceptionConsumer<R>(
+        val underlying: TagConsumer<R>,
+        val handler: TagConsumer<R>.(Exception) -> Unit) : TagConsumer<R> by underlying {
+
+    override fun onError(tag: Tag, exception: Exception) = handler(underlying, exception)
+}
+
+/**
+ * Allows simple exception handling. Any exceptions will forwarded to `handler` function.
+ * For more control of error handling, implement `onError` in your subclass of `TagConsumer`
+ */
+fun <R> TagConsumer<R>.catch(handler: TagConsumer<R>.(Exception) -> Unit): TagConsumer<R>
+        = DelegatingExceptionConsumer(this, handler)

--- a/shared/src/main/kotlin/exception-consumer.kt
+++ b/shared/src/main/kotlin/exception-consumer.kt
@@ -1,17 +1,18 @@
+package kotlinx.html.consumers
+
 import kotlinx.html.Tag
 import kotlinx.html.TagConsumer
-import kotlinx.html.div
 
 private class DelegatingExceptionConsumer<R>(
         val underlying: TagConsumer<R>,
-        val handler: TagConsumer<R>.(Exception) -> Unit) : TagConsumer<R> by underlying {
+        val handler: TagConsumer<R>.(Throwable) -> Unit) : TagConsumer<R> by underlying {
 
-    override fun onError(tag: Tag, exception: Exception) = handler(underlying, exception)
+    override fun onTagError(tag: Tag, exception: Throwable) = handler(underlying, exception)
 }
 
 /**
  * Allows simple exception handling. Any exceptions will forwarded to `handler` function.
- * For more control of error handling, implement `onError` in your subclass of `TagConsumer`
+ * For more control of error handling, implement `onTagError` in your subclass of `TagConsumer`
  */
-fun <R> TagConsumer<R>.catch(handler: TagConsumer<R>.(Exception) -> Unit): TagConsumer<R>
+fun <R> TagConsumer<R>.catch(handler: TagConsumer<R>.(Throwable) -> Unit): TagConsumer<R>
         = DelegatingExceptionConsumer(this, handler)

--- a/shared/src/main/kotlin/filter-consumer.kt
+++ b/shared/src/main/kotlin/filter-consumer.kt
@@ -77,6 +77,12 @@ private class FilterTagConsumer<T>(val downstream : TagConsumer<T>, val predicat
 
     private fun canPassCurrentLevel() = dropLevel == null && currentLevel !in skippedLevels
 
+    override fun onError(tag: Tag, exception: Exception) {
+        if (canPassCurrentLevel()) {
+            downstream.onError(tag, exception)
+        }
+    }
+
     override fun finalize(): T = downstream.finalize()
 }
 

--- a/shared/src/main/kotlin/filter-consumer.kt
+++ b/shared/src/main/kotlin/filter-consumer.kt
@@ -77,9 +77,9 @@ private class FilterTagConsumer<T>(val downstream : TagConsumer<T>, val predicat
 
     private fun canPassCurrentLevel() = dropLevel == null && currentLevel !in skippedLevels
 
-    override fun onError(tag: Tag, exception: Exception) {
+    override fun onTagError(tag: Tag, exception: Throwable) {
         if (canPassCurrentLevel()) {
-            downstream.onError(tag, exception)
+            downstream.onTagError(tag, exception)
         }
     }
 

--- a/shared/src/main/kotlin/finalize-consumer.kt
+++ b/shared/src/main/kotlin/finalize-consumer.kt
@@ -23,7 +23,7 @@ class FinalizeConsumer<F, T>(val downstream : TagConsumer<F>, val block : (F, Bo
     override fun onTagContent(content: CharSequence) = downstream.onTagContent(content)
     override fun onTagContentEntity(entity: Entities) = downstream.onTagContentEntity(entity)
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) = downstream.onTagContentUnsafe(block)
-    override fun onError(tag: Tag, exception: Exception) = downstream.onError(tag, exception)
+    override fun onTagError(tag: Tag, exception: Throwable) = downstream.onTagError(tag, exception)
 
     override fun finalize() = block(downstream.finalize(), level > 0)
 }

--- a/shared/src/main/kotlin/finalize-consumer.kt
+++ b/shared/src/main/kotlin/finalize-consumer.kt
@@ -23,6 +23,7 @@ class FinalizeConsumer<F, T>(val downstream : TagConsumer<F>, val block : (F, Bo
     override fun onTagContent(content: CharSequence) = downstream.onTagContent(content)
     override fun onTagContentEntity(entity: Entities) = downstream.onTagContentEntity(entity)
     override fun onTagContentUnsafe(block: Unsafe.() -> Unit) = downstream.onTagContentUnsafe(block)
+    override fun onError(tag: Tag, exception: Exception) = downstream.onError(tag, exception)
 
     override fun finalize() = block(downstream.finalize(), level > 0)
 }

--- a/shared/src/main/kotlin/measure-consumer.kt
+++ b/shared/src/main/kotlin/measure-consumer.kt
@@ -42,6 +42,10 @@ private class TimeMeasureConsumer<R>(val downstream : TagConsumer<R>) : TagConsu
         downstream.onTagContentUnsafe(block)
     }
 
+    override fun onError(tag: Tag, exception: Exception) {
+        downstream.onError(tag, exception)
+    }
+
     override fun finalize(): TimedResult<R> = TimedResult(downstream.finalize(), Date().getTime().toLong() - start.getTime())
 }
 

--- a/shared/src/main/kotlin/measure-consumer.kt
+++ b/shared/src/main/kotlin/measure-consumer.kt
@@ -42,8 +42,8 @@ private class TimeMeasureConsumer<R>(val downstream : TagConsumer<R>) : TagConsu
         downstream.onTagContentUnsafe(block)
     }
 
-    override fun onError(tag: Tag, exception: Exception) {
-        downstream.onError(tag, exception)
+    override fun onTagError(tag: Tag, exception: Throwable) {
+        downstream.onTagError(tag, exception)
     }
 
     override fun finalize(): TimedResult<R> = TimedResult(downstream.finalize(), Date().getTime().toLong() - start.getTime())

--- a/shared/src/main/kotlin/trace-consumer.kt
+++ b/shared/src/main/kotlin/trace-consumer.kt
@@ -29,10 +29,10 @@ class TraceConsumer<R>(val downstream : TagConsumer<R>) : TagConsumer<R> by down
         println("[$id]     ${tag.tagName}.$attribute changed to $value")
     }
 
-    override fun onError(tag: Tag, exception: Exception) {
+    override fun onTagError(tag: Tag, exception: Throwable) {
         println("[$id] exception in ${tag.tagName}: ${exception.message}")
 
-        downstream.onError(tag, exception)
+        downstream.onTagError(tag, exception)
     }
 
     override fun finalize(): R {

--- a/shared/src/main/kotlin/trace-consumer.kt
+++ b/shared/src/main/kotlin/trace-consumer.kt
@@ -29,6 +29,12 @@ class TraceConsumer<R>(val downstream : TagConsumer<R>) : TagConsumer<R> by down
         println("[$id]     ${tag.tagName}.$attribute changed to $value")
     }
 
+    override fun onError(tag: Tag, exception: Exception) {
+        println("[$id] exception in ${tag.tagName}: ${exception.message}")
+
+        downstream.onError(tag, exception)
+    }
+
     override fun finalize(): R {
         val v = downstream.finalize()
 


### PR DESCRIPTION
This is a proposal #21 

By default, `onError` will write to the underlying `TagConsumer` but there is a less-safe option to write to the innermost consumer using `tag.consumer`.