### PR TITLE
Publish to NPM via ANT

### DIFF
--- a/js/npm.templates/kotlinx-html-js/README.md
+++ b/js/npm.templates/kotlinx-html-js/README.md
@@ -1,0 +1,59 @@
+# kotlinx.html
+
+A kotlinx.html library provides DSL to build HTML to [Writer](http://docs.oracle.com/javase/8/docs/api/java/io/Writer.html)/[Appendable](http://docs.oracle.com/javase/8/docs/api/java/lang/Appendable.html) or DOM at JVM and browser (or other JavaScript engine) for 
+better [Kotlin programming](http://kotlinlang.org) for Web. 
+
+# Get started
+
+See [Getting started](https://github.com/kotlin/kotlinx.html/wiki/Getting-started) page for details how to include the library
+
+# DOM
+You can build DOM tree with JVM and JS naturally
+
+See example for JavaScript-targeted Kotlin
+
+```kotlin
+window.setInterval({
+    val myDiv = document.create.div("panel") {
+        p { 
+            +"Here is "
+            a("http://kotlinlang.org") { +"official Kotlin site" } 
+        }
+    }
+
+    document.getElementById("container")!!.appendChild(myDiv)
+
+    document.getElementById("container")!!.append {
+        div {
+            +"added it"
+        }
+    }
+}, 1000L)
+```
+
+# Stream
+You can build HTML directly to Writer (JVM only) or Appendable (both JVM and JS)
+
+```kotlin
+System.out.appendHTML().html {
+	body {
+		div {
+			a("http://kotlinlang.org") {
+				target = ATarget.blank
+				+"Main site"
+			}
+		}
+	}
+}
+```
+
+# Documentation
+
+See [wiki](https://github.com/kotlin/kotlinx.html/wiki) pages
+
+# Building 
+See [development](https://github.com/kotlin/kotlinx.html/wiki/Development) page for details
+
+# Old version
+
+See https://github.com/kotlinx/kotlinx.html.legacy for older version. We strongly recommend to migrate to latest version.

--- a/js/npm.templates/kotlinx-html-js/package.json
+++ b/js/npm.templates/kotlinx-html-js/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "kotlinx-html-js",
+  "version": "1.0.0",
+  "description": "Library for building HTML in Kotlin",
+  "main": "kotlinx-html-js.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Kotlin/kotlinx.html.git"
+  },
+  "keywords": [
+    "Kotlin",
+    "Language",
+    "HTML",
+    "JavaScript",
+    "JetBrains"
+  ],
+  "author": "JetBrains",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Kotlin/kotlinx.html/issues"
+  },
+  "homepage": "https://github.com/kotlin/kotlinx.html/wiki"
+}

--- a/npm_publish.xml
+++ b/npm_publish.xml
@@ -1,0 +1,143 @@
+<project name="Node.js utils" xmlns:if="ant:if" xmlns:unless="ant:unless">
+    <!-- Expected that these properties will be overridden by system properties -->
+    <property name="kotlin.deploy.version" value="0.0.0"/>
+    <property name="kotlin.deploy.tag" value="dev"/>
+    <property name="kotlin.npmjs.auth.token" value="AUTH"/>
+
+    <!-- Based on https://github.com/JetBrains/kotlin/blob/master/common.xml -->
+    <condition property="isWindows">
+        <os family="windows"/>
+    </condition>
+
+    <condition property="isMac">
+        <os family="mac"/>
+    </condition>
+
+    <condition property="isLinux">
+        <and>
+            <os family="unix"/>
+            <not>
+                <os family="mac"/>
+            </not>
+        </and>
+    </condition>
+
+    <property name="output" value="${basedir}/js/target/"/>
+    <property name="dependencies" value="${output}/dependencies"/>
+
+    <target name="make-dependency-dirs">
+        <mkdir dir="${dependencies}"/>
+        <mkdir dir="${dependencies}/download"/>
+    </target>
+    
+    <!-- Based on https://github.com/JetBrains/kotlin/blob/master/node_utils.xml -->
+    <property name="node.version" value="v6.3.1"/>
+
+    <property name="node.dir" value="${dependencies}/node"/>
+    <property name="node.executable" value="${node.dir}/bin/node"/>
+
+
+    <target name="download-nodejs-and-npm" depends="make-dependency-dirs">
+        <property name="linux-x86" value="linux-x86"/>
+
+        <property name="platform" value="win-x86" if:set="isWindows"/>
+        <property name="platform" value="darwin-x64" if:set="isMac"/>
+        <property name="platform" value="${linux-x86}" if:set="isLinux"/>
+
+        <property name="node.tar.gz" value="${dependencies}/download/node.tar.gz"/>
+
+        <property name="node.exe" value="${node.executable}.exe"/>
+
+        <property name="node.name.prefix" value="${platform}" unless:set="isWindows"/>
+        <property name="node.name.prefix" value="${linux-x86}" if:set="isWindows"/>
+
+        <property name="node.full.name" value="node-${node.version}-${node.name.prefix}"/>
+
+        <property name="url.node.tar.gz" value="https://nodejs.org/dist/${node.version}/${node.full.name}.tar.gz"/>
+        <property name="url.node.exe" value="https://nodejs.org/dist/${node.version}/${platform}/node.exe"/>
+
+
+        <get src="${url.node.tar.gz}" dest="${node.tar.gz}" usetimestamp="true"/>
+        <exec executable="tar" unless:set="isWindows">
+            <arg value="-zxf"/>
+            <arg path="${node.tar.gz}"/>
+            <arg value="-C"/>
+            <arg path="${dependencies}"/>
+        </exec>
+        <untar src="${node.tar.gz}" dest="${dependencies}" compression="gzip" if:set="isWindows"/>
+
+        <move file="${dependencies}/${node.full.name}" tofile="${dependencies}/node"/>
+        <delete dir="${dependencies}/${node.full.name}"/>
+        <delete file="${node.tar.gz}"/>
+
+        <sequential if:set="isWindows">
+            <get src="${url.node.exe}" dest="${node.exe}" usetimestamp="true"/>
+            <delete file="${node.executable}"/>
+        </sequential>
+    </target>
+
+    <macrodef name="node">
+        <attribute name="dir" default="."/>
+        <attribute name="failonerror" default="true"/>
+        <element name="args" implicit="true"/>
+
+        <sequential>
+            <exec executable="${node.executable}" dir="@{dir}" failonerror="@{failonerror}">
+                <args/>
+            </exec>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="npm">
+        <attribute name="command"/>
+        <attribute name="dir" default="."/>
+        <attribute name="failonerror" default="true"/>
+        <element name="args" optional="true" implicit="true"/>
+
+        <sequential>
+            <node dir="@{dir}" failonerror="@{failonerror}">
+                <arg file="${node.dir}/lib/node_modules/npm/bin/npm-cli.js"/>
+                <arg value="@{command}"/>
+                <args/>
+            </node>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="publish-to-npm">
+        <attribute name="template"/>
+        <attribute name="version"/>
+        <attribute name="tag"/>
+        <element name="actions" optional="true" implicit="true"/>
+        <sequential>
+            <property name="deploy_to_npm_dir" value="${output}/deploy_to_npm"/>
+            <property name="package_deploy_dir" value="${deploy_to_npm_dir}/@{template}"/>
+
+            <delete dir="${deploy_to_npm_dir}"/>
+
+            <mkdir dir="${deploy_to_npm_dir}"/>
+            <copy todir="${package_deploy_dir}">
+                <fileset dir="js/npm.templates/@{template}"/>
+            </copy>
+
+            <actions/>
+
+            <npm command="version" dir="${package_deploy_dir}">
+                <arg value="@{version}"/>
+            </npm>
+            <npm command="publish" dir="${package_deploy_dir}">
+                <arg value="--//registry.npmjs.org/:_authToken=${kotlin.npmjs.auth.token}"/>
+                <arg value="--tag"/>
+                <arg value="@{tag}"/>
+            </npm> 
+        </sequential>
+    </macrodef>
+
+
+    <target name="publish-kotlinx-html-js-to-npm" depends="download-nodejs-and-npm">
+        <publish-to-npm template="kotlinx-html-js" version="${kotlin.deploy.version}" tag="${kotlin.deploy.tag}">
+            <copy file="${output}/classes/kotlinx-html-js.js" todir="${package_deploy_dir}" failonerror="true" />
+            <copy file="${output}/classes/kotlinx-html-js.meta.js" todir="${package_deploy_dir}" failonerror="true" />
+        </publish-to-npm>
+    </target>
+
+</project>


### PR DESCRIPTION
In order to publish kotlinx-html-js to NPM you should
- build the library, e.g. `mvn clean package -DskipTests`
- run `ant -f npm_publish.xml publish-kotlinx-html-js-to-npm -Dkotlin.deploy.version=<version> -Dkotlin.deploy.tag=<tag> -Dkotlin.npmjs.auth.token=<token>`