### PR TITLE
make a namespace parameter of HTMLTag be var instead of val

### DIFF
--- a/jvm/src/test/kotlin/streaming.kt
+++ b/jvm/src/test/kotlin/streaming.kt
@@ -370,6 +370,25 @@ class TestStreaming {
         assertEquals("<html><body><svg xmlns=\"http://www.w3.org/2000/svg\"></svg></body></html>", t)
     }
 
+    @test fun `able to create html with namespace`() {
+        val html = createHTML(false).html {
+            namespace = "http://www.w3.org/1999/xhtml"
+            body {
+                h1 {
+                    +"header"
+                }
+                div {
+                    +"content"
+                    span {
+                        +"yo"
+                    }
+                }
+            }
+        }
+
+        assertEquals("<html xmlns=\"http://www.w3.org/1999/xhtml\"><body><h1>header</h1><div>content<span>yo</span></div></body></html>", html)
+    }
+
     @test fun `pretty print`() {
         val x = StringBuilder().appendHTML().html {
             body {

--- a/shared/src/main/kotlin/htmltag.kt
+++ b/shared/src/main/kotlin/htmltag.kt
@@ -1,12 +1,12 @@
 package kotlinx.html
 
-import kotlinx.html.impl.*
+import kotlinx.html.impl.DelegatingMap
 
 open class HTMLTag(
         override val tagName : String,
         override val consumer : TagConsumer<*>,
         initialAttributes : Map<String, String>,
-        override val namespace : String? = null,
+        override var namespace : String? = null,
         override val inlineTag: Boolean,
         override val emptyTag: Boolean) : Tag {
 


### PR DESCRIPTION
make a namespace parameter of HTMLTag be var instead of val. fixes #84