### PR TITLE
Change version 0.6.13-SNAPSHOT -> 0.7.1-SNAPSHOT.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 group = "org.jetbrains.kotlinx"
-version = "0.6.13-SNAPSHOT"
+version = "0.7.1-SNAPSHOT"
 
 /**
  * If "release" profile is used the "-SNAPSHOT" suffix of the version is removed.


### PR DESCRIPTION
To prepare to release we need to change the version from `0.6.13` to `0.7.1`.