### PR TITLE
Change package for Event interface to get rid of clash with stdlib

### DIFF
--- a/buildSrc/src/main/kotlin/kotlinx/html/generate/main.kt
+++ b/buildSrc/src/main/kotlin/kotlinx/html/generate/main.kt
@@ -111,9 +111,7 @@ fun generate(packg: String, todir: String, jsdir: String) {
             packg(packg + ".js")
             emptyLine()
             import("kotlinx.html.*")
-            import("kotlinx.html.attributes.*")
-            import("kotlinx.html.dom.*")
-            import("org.w3c.dom.events.*")
+            import("kotlinx.html.org.w3c.dom.events.Event")
             emptyLine()
 
             doNotEditWarning()

--- a/src/commonMain/kotlin/Event.kt
+++ b/src/commonMain/kotlin/Event.kt
@@ -1,4 +1,4 @@
-package org.w3c.dom.events
+package kotlinx.html.org.w3c.dom.events
 
 expect interface Event {
     fun stopPropagation()

--- a/src/commonMain/kotlin/api.kt
+++ b/src/commonMain/kotlin/api.kt
@@ -1,6 +1,6 @@
 package kotlinx.html
 
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 interface TagConsumer<out R> {
     fun onTagStart(tag: Tag)

--- a/src/commonMain/kotlin/delayed-consumer.kt
+++ b/src/commonMain/kotlin/delayed-consumer.kt
@@ -1,7 +1,7 @@
 package kotlinx.html.consumers
 
 import kotlinx.html.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 class DelayedConsumer<T>(val downstream: TagConsumer<T>) : TagConsumer<T> {
     private var delayed: Tag? = null

--- a/src/commonMain/kotlin/filter-consumer.kt
+++ b/src/commonMain/kotlin/filter-consumer.kt
@@ -1,7 +1,7 @@
 package kotlinx.html.consumers
 
 import kotlinx.html.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 object PredicateResults {
     val PASS = PredicateResult.PASS

--- a/src/commonMain/kotlin/finalize-consumer.kt
+++ b/src/commonMain/kotlin/finalize-consumer.kt
@@ -1,7 +1,7 @@
 package kotlinx.html.consumers
 
 import kotlinx.html.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 class FinalizeConsumer<F, T>(val downstream: TagConsumer<F>, val block: (F, Boolean) -> T) : TagConsumer<T> {
     private var level = 0

--- a/src/commonMain/kotlin/measure-consumer.kt
+++ b/src/commonMain/kotlin/measure-consumer.kt
@@ -1,7 +1,7 @@
 package kotlinx.html.consumers
 
 import kotlinx.html.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 data class TimedResult<T>(val result: T, val time: Long)
 

--- a/src/commonMain/kotlin/stream.kt
+++ b/src/commonMain/kotlin/stream.kt
@@ -2,7 +2,7 @@ package kotlinx.html.stream
 
 import kotlinx.html.*
 import kotlinx.html.consumers.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 class HTMLStreamBuilder<out O : Appendable>(val out: O, val prettyPrint: Boolean, val xhtmlCompatible: Boolean) :
     TagConsumer<O> {

--- a/src/jsMain/kotlin/EventJs.kt
+++ b/src/jsMain/kotlin/EventJs.kt
@@ -1,6 +1,6 @@
-package org.w3c.dom.events // ktlint-disable filename
+package kotlinx.html.org.w3c.dom.events // ktlint-disable filename
 
-import org.w3c.dom.*
+import org.w3c.dom.events.EventTarget
 
 public actual external interface Event {
     val type: String

--- a/src/jsMain/kotlin/dom-js.kt
+++ b/src/jsMain/kotlin/dom-js.kt
@@ -2,8 +2,8 @@ package kotlinx.html.dom
 
 import kotlinx.html.*
 import kotlinx.html.consumers.*
+import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.*
-import org.w3c.dom.events.*
 
 private inline fun HTMLElement.setEvent(name: String, noinline callback : (Event) -> Unit) : Unit {
     asDynamic()[name] = callback

--- a/src/jsMain/kotlin/generated/gen-event-attrs-js.kt
+++ b/src/jsMain/kotlin/generated/gen-event-attrs-js.kt
@@ -1,9 +1,7 @@
 package kotlinx.html.js
 
 import kotlinx.html.*
-import kotlinx.html.attributes.*
-import kotlinx.html.dom.*
-import org.w3c.dom.events.*
+import kotlinx.html.org.w3c.dom.events.Event
 
 /*******************************************************************************
     DO NOT EDIT

--- a/src/jvmMain/kotlin/EventJvm.kt
+++ b/src/jvmMain/kotlin/EventJvm.kt
@@ -1,4 +1,4 @@
-package org.w3c.dom.events // ktlint-disable filename
+package kotlinx.html.org.w3c.dom.events // ktlint-disable filename
 
 actual interface Event {
     actual fun stopPropagation()

--- a/src/jvmMain/kotlin/dom-jvm.kt
+++ b/src/jvmMain/kotlin/dom-jvm.kt
@@ -2,8 +2,8 @@ package kotlinx.html.dom
 
 import kotlinx.html.*
 import kotlinx.html.consumers.*
+import kotlinx.html.org.w3c.dom.events.Event
 import org.w3c.dom.*
-import org.w3c.dom.events.*
 import org.xml.sax.*
 import java.io.*
 import java.util.*

--- a/src/nativeMain/kotlin/EventNative.kt
+++ b/src/nativeMain/kotlin/EventNative.kt
@@ -1,4 +1,4 @@
-package org.w3c.dom.events // ktlint-disable filename
+package kotlinx.html.org.w3c.dom.events // ktlint-disable filename
 
 actual interface Event {
     actual fun stopPropagation()


### PR DESCRIPTION
`Event` interface in `org.w3c.dom.events` package clashes with stdlib class `Event`.