### PR TITLE
Enable linuxArm64 native target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,6 +139,7 @@ kotlin {
 
     mingwX64()
     linuxX64()
+    linuxArm64()
     iosX64()
     iosArm64()
     iosArm32()
@@ -211,6 +212,7 @@ kotlin {
         val nativeTargets = listOf(
             "mingwX64",
             "linuxX64",
+            "linuxArm64",
             "iosX64",
             "iosArm64",
             "iosArm32",


### PR DESCRIPTION
I'm trying to work towards https://youtrack.jetbrains.com/issue/KTOR-5753 and bumped into

> No matching variant of org.jetbrains.kotlinx:kotlinx-html:0.8.1 was found.

With this PR, building on linux x86-64 seems to work fine and cross-compile to arm64.

Let me know if there is something else I can help with.