### PR TITLE
Add the `crossorigin` attribute to the `<script>` element

### DIFF
--- a/buildSrc/src/main/resources/html_5.xsd
+++ b/buildSrc/src/main/resources/html_5.xsd
@@ -608,6 +608,14 @@
             </xsd:attribute>
             <xsd:attribute name="nonce" type="xsd:string"/>
             <xsd:attribute name="integrity" type="xsd:string"/>
+            <xsd:attribute name="crossorigin">
+                <xsd:simpleType>
+                    <xsd:restriction base="xsd:NMTOKEN">
+                        <xsd:enumeration value="anonymous"/>
+                        <xsd:enumeration value="use-credentials"/>
+                    </xsd:restriction>
+                </xsd:simpleType>
+            </xsd:attribute>
         </xsd:complexType>
     </xsd:element>
 

--- a/src/commonMain/kotlin/generated/gen-attributes.kt
+++ b/src/commonMain/kotlin/generated/gen-attributes.kt
@@ -46,6 +46,8 @@ internal val attributeKeyGenKeyTypeEnumKeyGenKeyTypeValues : Attribute<KeyGenKey
 
 internal val attributeRunAtEnumRunAtValues : Attribute<RunAt> = EnumAttribute(runAtValues)
 
+internal val attributeScriptCrossoriginEnumScriptCrossoriginValues : Attribute<ScriptCrossorigin> = EnumAttribute(scriptCrossoriginValues)
+
 internal val attributeTextAreaWrapEnumTextAreaWrapValues : Attribute<TextAreaWrap> = EnumAttribute(textAreaWrapValues)
 
 internal val attributeThScopeEnumThScopeValues : Attribute<ThScope> = EnumAttribute(thScopeValues)

--- a/src/commonMain/kotlin/generated/gen-consumer-tags.kt
+++ b/src/commonMain/kotlin/generated/gen-consumer-tags.kt
@@ -538,12 +538,12 @@ inline fun <T, C : TagConsumer<T>> C.samp(classes : String? = null, crossinline 
  * Script statements
  */
 @HtmlTagMarker
-fun <T, C : TagConsumer<T>> C.script(type : String? = null, src : String? = null, content : String = "") : T = SCRIPT(attributesMapOf("type", type,"src", src), this).visitAndFinalize(this, {+content})
+fun <T, C : TagConsumer<T>> C.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, content : String = "") : T = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), this).visitAndFinalize(this, {+content})
 /**
  * Script statements
  */
 @HtmlTagMarker
-inline fun <T, C : TagConsumer<T>> C.script(type : String? = null, src : String? = null, crossinline block : SCRIPT.() -> Unit = {}) : T = SCRIPT(attributesMapOf("type", type,"src", src), this).visitAndFinalize(this, block)
+inline fun <T, C : TagConsumer<T>> C.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, crossinline block : SCRIPT.() -> Unit = {}) : T = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), this).visitAndFinalize(this, block)
 
 /**
  * Generic document or application section

--- a/src/commonMain/kotlin/generated/gen-enums.kt
+++ b/src/commonMain/kotlin/generated/gen-enums.kt
@@ -368,6 +368,13 @@ object ScriptType {
 }
 
 @Suppress("unused")
+enum class ScriptCrossorigin(override val realValue : String) : AttributeEnum {
+    anonymous("anonymous"),
+    useCredentials("use-credentials")
+}
+
+internal val scriptCrossoriginValues : Map<String, ScriptCrossorigin> = ScriptCrossorigin.values().associateBy { it.realValue }
+@Suppress("unused")
 object StyleType {
     val textCss : String = "text/css"
 

--- a/src/commonMain/kotlin/generated/gen-tag-unions.kt
+++ b/src/commonMain/kotlin/generated/gen-tag-unions.kt
@@ -63,14 +63,24 @@ inline fun FlowOrMetaDataOrPhrasingContent.noScript(classes : String? = null, cr
  * Script statements
  */
 @HtmlTagMarker
-inline fun FlowOrMetaDataOrPhrasingContent.script(type : String? = null, src : String? = null, crossinline block : SCRIPT.() -> Unit = {}) : Unit = SCRIPT(attributesMapOf("type", type,"src", src), consumer).visit(block)
+inline fun FlowOrMetaDataOrPhrasingContent.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, crossinline block : SCRIPT.() -> Unit = {}) : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), consumer).visit(block)
 @Deprecated("This tag doesn't support content or requires unsafe (try unsafe {})")
 @Suppress("DEPRECATION")
 /**
  * Script statements
  */
 @HtmlTagMarker
-fun FlowOrMetaDataOrPhrasingContent.script(type : String? = null, src : String? = null, content : String = "") : Unit = SCRIPT(attributesMapOf("type", type,"src", src), consumer).visit({+content})
+fun FlowOrMetaDataOrPhrasingContent.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, content : String = "") : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), consumer).visit({+content})
+@HtmlTagMarker
+inline fun FlowOrMetaDataOrPhrasingContent.anonymousScript(type : String? = null, src : String? = null, crossinline block : SCRIPT.() -> Unit = {}) : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", ScriptCrossorigin.anonymous.realValue), consumer).visit(block)
+@HtmlTagMarker
+inline fun FlowOrMetaDataOrPhrasingContent.useCredentialsScript(type : String? = null, src : String? = null, crossinline block : SCRIPT.() -> Unit = {}) : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", ScriptCrossorigin.useCredentials.realValue), consumer).visit(block)
+@Deprecated("This tag doesn't support content or requires unsafe (try unsafe {})")
+@Suppress("DEPRECATION")
+@HtmlTagMarker
+fun FlowOrMetaDataOrPhrasingContent.anonymousScript(type : String? = null, src : String? = null, content : String = "") : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", ScriptCrossorigin.anonymous.realValue), consumer).visit({+content})
+@HtmlTagMarker
+fun FlowOrMetaDataOrPhrasingContent.useCredentialsScript(type : String? = null, src : String? = null, content : String = "") : Unit = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", ScriptCrossorigin.useCredentials.realValue), consumer).visit({+content})
 
 
 /**

--- a/src/commonMain/kotlin/generated/gen-tags-s.kt
+++ b/src/commonMain/kotlin/generated/gen-tags-s.kt
@@ -50,6 +50,10 @@ open class SCRIPT(initialAttributes : Map<String, String>, override val consumer
         get()  = attributeStringString.get(this, "integrity")
         set(newValue) {attributeStringString.set(this, "integrity", newValue)}
 
+    var crossorigin : ScriptCrossorigin
+        get()  = attributeScriptCrossoriginEnumScriptCrossoriginValues.get(this, "crossorigin")
+        set(newValue) {attributeScriptCrossoriginEnumScriptCrossoriginValues.set(this, "crossorigin", newValue)}
+
     @Deprecated("This tag most likely doesn't support text content or requires unsafe content (try unsafe {}")
     override operator fun Entities.unaryPlus() : Unit {
         @Suppress("DEPRECATION") entity(this)

--- a/src/jsMain/kotlin/generated/gen-consumer-tags-js.kt
+++ b/src/jsMain/kotlin/generated/gen-consumer-tags-js.kt
@@ -539,12 +539,12 @@ public inline fun TagConsumer<HTMLElement>.samp(classes : String? = null, crossi
  * Script statements
  */
 @HtmlTagMarker
-public fun TagConsumer<HTMLElement>.script(type : String? = null, src : String? = null, content : String = "") : HTMLScriptElement = SCRIPT(attributesMapOf("type", type,"src", src), this).visitAndFinalize(this, {+content}) as HTMLScriptElement
+public fun TagConsumer<HTMLElement>.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, content : String = "") : HTMLScriptElement = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), this).visitAndFinalize(this, {+content}) as HTMLScriptElement
 /**
  * Script statements
  */
 @HtmlTagMarker
-public inline fun TagConsumer<HTMLElement>.script(type : String? = null, src : String? = null, crossinline block : SCRIPT.() -> Unit = {}) : HTMLScriptElement = SCRIPT(attributesMapOf("type", type,"src", src), this).visitAndFinalize(this, block) as HTMLScriptElement
+public inline fun TagConsumer<HTMLElement>.script(type : String? = null, src : String? = null, crossorigin : ScriptCrossorigin? = null, crossinline block : SCRIPT.() -> Unit = {}) : HTMLScriptElement = SCRIPT(attributesMapOf("type", type,"src", src,"crossorigin", crossorigin?.enumEncode()), this).visitAndFinalize(this, block) as HTMLScriptElement
 
 /**
  * Generic document or application section


### PR DESCRIPTION
This project is very interesting in combination with other tools like htmx. To safely include such libraries we should allow the crossorigin in the script tag as described [here](https://htmx.org/docs/#installing)

See [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) for more details about the attribute.